### PR TITLE
Update detected_urls.txt

### DIFF
--- a/detected_urls.txt
+++ b/detected_urls.txt
@@ -982,3 +982,4 @@ onaiw3.com
 crypto-pulsecce.com
 bitdexchain.com
 nexinks.com
+bitclaim.net

--- a/detected_urls.txt
+++ b/detected_urls.txt
@@ -296,7 +296,6 @@ doexz.org
 fkq30.com
 aeonmining.net
 mancuifcfx.com
-bitclaim.net
 xaitonium.com
 trade-finex.global
 potionalpha.com
@@ -460,7 +459,6 @@ pacextrades.com
 mgportfoliomgmt.com
 okxph.life
 technologycompass.shop
-chainabuse.report
 trust-xv.com
 pbdexapp.vip
 dfaled.com
@@ -498,7 +496,6 @@ interstellar-probes.org
 jupiter-coupon.com
 toptiersafeshares.com
 ra-me.com
-scam-assist.co.uk
 hashpalette.site
 innovationpathe-global.com
 btc-token.com
@@ -508,9 +505,7 @@ cryptwave.com
 experttradeequity.com
 trust-exd.com
 cars-work.com
-theadviser.com.au
 lwex-exchange.com
-moneymanagement.com.au
 zintorik.io
 coinmaske.com
 evoluxcapital.com
@@ -800,17 +795,13 @@ pmtcoin.com
 rendwex.com
 solenamarketx.com
 quantxes.com
-
 bytewealt.com
 fortcas.com
 currencysplus.com
 spumachine.com
-token.im
 133ex.com
 zzcoingy.com
 blockchainxe.com
-abc.net.au
-news.com.au
 angel-army.com
 myblackblock.com
 yrixolon.com
@@ -950,6 +941,7 @@ onocafb.top
 definft.live
 prestige-tb.online
 kaopex.com
+
 fedeth.shop
 asecoins.com
 symfa-app.com


### PR DESCRIPTION
Removing False Positives:

abc.net.au - Legitimate Australian Broadcasting Corporation news website. Probably included accidentally because it contains “abc” which is often used in scam domains. news.com.au - Real Australian news outlet owned by News Corp. Also not crypto-related or malicious. theadviser.com.au - A genuine financial publication (mortgage/broker industry), not related to crypto phishing. moneymanagement.com.au - Legitimate Australian financial site. Likely flagged by keyword match. scam-assist.co.uk - Appears to be a legitimate anti-fraud service; not a scam itself. Misleading name could have triggered listing. chainabuse.report - Official Chainabuse reporting platform by TRM Labs a legitimate site used to report crypto scams. Almost certainly a false positive. token.im - Real mobile Ethereum wallet (“imToken”). Trusted, widely used. Should not be blacklisted.